### PR TITLE
fixed os detection not working properly on linux

### DIFF
--- a/Brotli.NET/Brotli.Core/Interop/NativeLibraryLoader.cs
+++ b/Brotli.NET/Brotli.Core/Interop/NativeLibraryLoader.cs
@@ -17,15 +17,15 @@ namespace Brotli
         internal static bool Is64Bit = false;
         static NativeLibraryLoader()
         {
-            string windir = Environment.GetEnvironmentVariable("windir");
-            if (!string.IsNullOrEmpty(windir) && windir.Contains(@"\") && Directory.Exists(windir))
+            string Windir = Environment.GetEnvironmentVariable("windir");
+            if (!string.IsNullOrEmpty(Windir) && Windir.Contains(@"\") && Directory.Exists(Windir))
             {
                 IsWindows = true;
             }
             else if (File.Exists(@"/proc/sys/kernel/ostype"))
             {
-                string osType = File.ReadAllText(@"/proc/sys/kernel/ostype");
-                if (osType.StartsWith("Linux", StringComparison.OrdinalIgnoreCase))
+                string OSType = File.ReadAllText(@"/proc/sys/kernel/ostype");
+                if (OSType.StartsWith("Linux", StringComparison.OrdinalIgnoreCase))
                 {
                     // Note: Android gets here too
                     IsLinux = true;


### PR DESCRIPTION
previously, the code block in `#if NET35 || NET40 || NET462` would be used on linux, which incorrectly tells brotli that it is running on windows.  if you were to manually delete that line and the compiler directives, it would then fail to compile on linux, due to runtimeinformation apparently not existing.  this should fix inventories not syncing on linux.

the solution in this patch is taken from https://github.com/Pkcs11Interop/Pkcs11Interop/blob/3.2.0/src/Pkcs11Interop/Pkcs11Interop/Common/Platform.cs which is licensed under the apache 2 license.

i do not have windows, so somebody else is going to have to test it there.