### PR TITLE
Fix platform detection being broken for .NET 4.6 version of the library

### DIFF
--- a/Brotli.NET/Brotli.Core/Brotli.Core.csproj
+++ b/Brotli.NET/Brotli.Core/Brotli.Core.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
@@ -39,5 +39,6 @@ For more document,please visit https://github.com/XieJJ99/brotli.net.</Descripti
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" Condition=" '$(TargetFramework)' == 'net45' " />
+    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
   </ItemGroup>
 </Project>

--- a/Brotli.NET/Brotli.Core/Interop/NativeLibraryLoader.cs
+++ b/Brotli.NET/Brotli.Core/Interop/NativeLibraryLoader.cs
@@ -18,14 +18,11 @@ namespace Brotli
         internal static bool Is64Bit = false;
         static NativeLibraryLoader()
         {
-#if NET35 || NET40 || NET462
-            IsWindows=true;
-#else
             IsWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
             IsLinux = RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
             IsMacOSX = RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
             IsNetCore = RuntimeInformation.FrameworkDescription.StartsWith(".NET Core");
-#endif
+
             if (!IsWindows && !IsLinux && !IsMacOSX)
             {
                 throw new InvalidOperationException("Unsupported platform.");


### PR DESCRIPTION
For some reason the original version of the library hardcodes the library to be Windows in all cases.